### PR TITLE
Upgrade azure library

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 env:
   CI: true
   CI_SNAPSHOT_RELEASE: +publishSigned
-  SCALA_VERSION: 2.12.11
+  SCALA_VERSION: 2.12.12
 jobs:
   validate:
     name: Scala ${{ matrix.scala }}, Java ${{ matrix.java }}
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [adopt@1.8, adopt@1.11, adopt@1.14]
-        scala: [2.12.11, 2.13.1]
+        scala: [2.12.12, 2.13.3]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - master
-    tags: 
+    tags:
       - '*'
 env:
   CI: true
-  SCALA_VERSION: 2.12.11
+  SCALA_VERSION: 2.12.12
 jobs:
   release:
     name: Release
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v5
-      - uses: olafurpg/setup-gpg@v2    
+      - uses: olafurpg/setup-gpg@v2
       - name: Cache Coursier
         uses: actions/cache@v1
         with:
@@ -34,7 +34,7 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}        
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,18 +1,35 @@
-version = 2.5.3
-
-style = default
+version = "2.5.3"
 
 maxColumn = 100
 
-// Vertical alignment is pretty, but leads to bigger diffs
-align.preset = none
+continuationIndent.callSite = 2
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  preset = none
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  multiline = false
+  openParenCallSite = false
+  openParenDefnSite = false
+
+  tokens = ["%", "%%"]
+}
 
 danglingParentheses.preset = false
 
-rewrite.rules = [
-  AvoidInfix
-  RedundantBraces
-  RedundantParens
-  AsciiSortImports
-  PreferCurlyFors
-]
+docstrings = JavaDoc
+
+rewrite {
+  rules = [
+    AvoidInfix
+    RedundantBraces
+    RedundantParens
+    AsciiSortImports
+    PreferCurlyFors
+  ]
+  redundantBraces.maxLines = 1
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,12 @@
 val catsV = "2.1.1"
-val catsEffectV = "2.1.3"
-
-val fs2V = "2.4.1"
-
-val circeV = "0.12.3"
-val specs2V = "4.9.4"
-
+val catsEffectV = "2.1.4"
+val fs2V = "2.4.4"
+val circeV = "0.13.0"
+val specs2V = "4.10.3"
+// compiler plugins
 val kindProjectorV = "0.11.0"
 val betterMonadicForV = "0.3.1"
 
-// Projects
 lazy val `cosmos4s` = project
   .in(file("."))
   .disablePlugins(MimaPlugin)
@@ -79,21 +76,21 @@ lazy val site = project
 
 // General Settings
 lazy val commonSettings = Seq(
-  scalaVersion := "2.13.1",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.11"),
+  scalaVersion := "2.13.3",
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.12"),
   addCompilerPlugin(
     ("org.typelevel" %% "kind-projector" % kindProjectorV).cross(CrossVersion.full)),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % betterMonadicForV),
   libraryDependencies ++= Seq(
-    "com.azure" % "azure-cosmos" % "4.0.1-beta.2",
-    "org.typelevel" %% "cats-core" % catsV,
-    "org.typelevel" %% "cats-effect" % catsEffectV,
-    "co.fs2" %% "fs2-reactive-streams" % fs2V,
-    "io.circe" %% "circe-core" % circeV,
-    "io.circe" %% "circe-parser" % circeV,
-    "io.circe" %% "circe-jackson210" % "0.13.0",
-    "org.specs2" %% "specs2-core" % specs2V % Test,
-    "org.specs2" %% "specs2-scalacheck" % specs2V % Test
+    "com.azure"      % "azure-cosmos"         % "4.3.2-beta.2",
+    "org.typelevel" %% "cats-core"            % catsV,
+    "org.typelevel" %% "cats-effect"          % catsEffectV,
+    "co.fs2"        %% "fs2-reactive-streams" % fs2V,
+    "io.circe"      %% "circe-core"           % circeV,
+    "io.circe"      %% "circe-parser"         % circeV,
+    "io.circe"      %% "circe-jackson210"     % "0.13.0",
+    "org.specs2"    %% "specs2-core"          % specs2V % Test,
+    "org.specs2"    %% "specs2-scalacheck"    % specs2V % Test
   )
 )
 

--- a/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
@@ -96,7 +96,7 @@ object IndexedCosmosContainer {
               container
                 .queryItems(
                   query,
-                  options.toCosmos.setPartitionKey(new PartitionKey(partitionKey)),
+                  options.build().setPartitionKey(new PartitionKey(partitionKey)),
                   classOf[JsonNode])
                 .byPage()
             )

--- a/core/src/main/scala/com/banno/cosmos4s/RawCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/RawCosmosContainer.scala
@@ -71,7 +71,7 @@ object RawCosmosContainer {
           ReactorCore.fluxToStream(
             Sync[F].delay(
               container
-                .queryItems(query, options.toCosmos, classOf[JsonNode])
+                .queryItems(query, options.build(), classOf[JsonNode])
                 .byPage()
             )
           )

--- a/core/src/main/scala/com/banno/cosmos4s/ReactorCore.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/ReactorCore.scala
@@ -21,7 +21,7 @@ import cats.effect._
 import cats.effect.implicits._
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import fs2._
+import fs2.Stream
 import fs2.interop.reactivestreams._
 
 object ReactorCore {
@@ -39,6 +39,7 @@ object ReactorCore {
         Sync[F].raiseError[A](new Throwable("Mono to Effect Conversion failed to produce value"))) {
         Sync[F].pure
       })
+
   def fluxToStream[F[_]: ConcurrentEffect: ContextShift, A](m: F[Flux[A]]): fs2.Stream[F, A] =
     Stream
       .eval(m)

--- a/core/src/main/scala/com/banno/cosmos4s/types/QueryOptions.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/types/QueryOptions.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.cosmos4s.types
+
+import com.azure.cosmos.models.CosmosQueryRequestOptions
+import cats.implicits._
+
+final class QueryOptions private (
+    val maxDegreeOfParallelism: Option[Int],
+    val maxBufferedItemCount: Option[Int]
+)
+
+object QueryOptions {
+
+  val default: QueryOptions = new QueryOptions(None, None)
+
+  implicit class QueryOptionSyntax(qo: QueryOptions) {
+    def withMaxDegreeOfParallelism(value: Int): QueryOptions =
+      new QueryOptions(
+        maxDegreeOfParallelism = value.some,
+        maxBufferedItemCount = qo.maxBufferedItemCount)
+
+    def withMaxBufferedItemCount(value: Int): QueryOptions =
+      new QueryOptions(
+        maxDegreeOfParallelism = qo.maxDegreeOfParallelism,
+        maxBufferedItemCount = value.some)
+
+    private[cosmos4s] def toCosmos: CosmosQueryRequestOptions = {
+      val cosmosQueryOptions = new CosmosQueryRequestOptions()
+      qo.maxDegreeOfParallelism.foreach(cosmosQueryOptions.setMaxDegreeOfParallelism)
+      qo.maxBufferedItemCount.foreach(cosmosQueryOptions.setMaxBufferedItemCount)
+      cosmosQueryOptions
+    }
+  }
+}

--- a/core/src/main/scala/com/banno/cosmos4s/types/QueryOptions.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/types/QueryOptions.scala
@@ -20,8 +20,8 @@ import com.azure.cosmos.models.CosmosQueryRequestOptions
 import cats.implicits._
 
 final class QueryOptions private (
-    val maxDegreeOfParallelism: Option[Int],
-    val maxBufferedItemCount: Option[Int])
+    maxDegreeOfParallelism: Option[Int],
+    maxBufferedItemCount: Option[Int])
     extends Serializable {
 
   private[this] def copy(
@@ -35,12 +35,15 @@ final class QueryOptions private (
   def withMaxBufferedItemCount(value: Option[Int]): QueryOptions =
     this.copy(maxBufferedItemCount = value)
 
+  private val getMaxDegreeOfParallelism: Option[Int] = maxDegreeOfParallelism
+  private val getMaxBufferedItemCount: Option[Int] = maxBufferedItemCount
+
   override def toString: String = s"QueryOptions($maxDegreeOfParallelism, $maxBufferedItemCount)"
 
   override def equals(o: Any): Boolean =
     o match {
       case x: QueryOptions =>
-        (this.maxDegreeOfParallelism == x.maxDegreeOfParallelism) && (this.maxBufferedItemCount == x.maxBufferedItemCount)
+        (this.maxDegreeOfParallelism == x.getMaxDegreeOfParallelism) && (this.maxBufferedItemCount == x.getMaxBufferedItemCount)
       case _ => false
     }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
 // addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.12")
 
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
+addSbtPlugin("com.geirsson"      % "sbt-ci-release"         % "1.5.3")
 addSbtPlugin("io.chrisdavenport" % "sbt-mima-version-check" % "0.1.2")
-addSbtPlugin("io.chrisdavenport" % "sbt-no-publish" % "0.1.0")
-
-addSbtPlugin("com.47deg" % "sbt-microsites" % "1.1.5")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.1.5")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
+addSbtPlugin("io.chrisdavenport" % "sbt-no-publish"         % "0.1.0")
+addSbtPlugin("com.47deg"         % "sbt-microsites"         % "1.2.1")
+addSbtPlugin("org.scalameta"     % "sbt-mdoc"               % "2.2.5")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"           % "2.4.2")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"             % "5.6.0")


### PR DESCRIPTION
- Update sbt and its plugins
- Update scala versions to 2.12.12 and 2.13.3
- Update azure cosmosdb to latest beta version: 4.3.2-beta.2
- Add `QueryOptions` class to wrap new `CosmosQueryRequestOptions`
- Update scalafmt settings and apply them
- Minor cleanup

Co-authored-by: Benigno Villa Fernandez <benigno.villa@banno.com>