### PR TITLE
Handle lookup error in expected way

### DIFF
--- a/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
@@ -110,14 +110,16 @@ object IndexedCosmosContainer {
     def lookup(partitionKey: String, id: String): F[Option[Json]] =
       cats.data
         .OptionT(
-          ReactorCore.monoToEffectOpt(
-            Sync[F].delay(
-              container.readItem(
-                id,
-                new PartitionKey(partitionKey),
-                new CosmosItemRequestOptions(),
-                classOf[JsonNode])
-            )).recoverWith{case _: NotFoundException => Sync[F].pure(None)}
+          ReactorCore
+            .monoToEffectOpt(
+              Sync[F].delay(
+                container.readItem(
+                  id,
+                  new PartitionKey(partitionKey),
+                  new CosmosItemRequestOptions(),
+                  classOf[JsonNode])
+              ))
+            .recoverWith { case _: NotFoundException => Sync[F].pure(None) }
         )
         .subflatMap(response => Option(response.getItem()))
         .map(jacksonToCirce(_))

--- a/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import fs2.Stream
 import io.circe._
 import io.circe.jackson._
+import com.azure.cosmos.implementation.NotFoundException
 
 trait IndexedCosmosContainer[F[_], K, I, V] {
   def query(
@@ -116,7 +117,7 @@ object IndexedCosmosContainer {
                 new PartitionKey(partitionKey),
                 new CosmosItemRequestOptions(),
                 classOf[JsonNode])
-            ))
+            )).recoverWith{case _: NotFoundException => Sync[F].pure(None)}
         )
         .subflatMap(response => Option(response.getItem()))
         .map(jacksonToCirce(_))


### PR DESCRIPTION
According to the underlying docs from the azure library, `readItem` will return a `NotFoundException` when an item doesn't exist in Cosmos. 

```
     * @return an {@link Mono} containing the Cosmos item response with the read item or an error.

```

In order to keep semantics with how we would expect a function like this to operate, if the case of that failure, we should be returning `None`.  