### PR TITLE
One chunk per page

### DIFF
--- a/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
@@ -103,9 +103,8 @@ object IndexedCosmosContainer {
             )
           )
         }
-        .flatMap(page => Stream.fromIterator(page.getElements().iterator().asScala))
-        .map(jacksonToCirce(_))
-        .evalMap(_.as[A].liftTo[F])
+        .flatMap(page => Stream.iterable(page.getElements().asScala))
+        .evalMapChunk(jacksonToCirce(_).as[A].liftTo[F])
 
     def lookup(partitionKey: String, id: String): F[Option[Json]] =
       cats.data

--- a/core/src/main/scala/com/banno/cosmos4s/RawCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/RawCosmosContainer.scala
@@ -76,9 +76,8 @@ object RawCosmosContainer {
             )
           )
         }
-        .flatMap(page => Stream.fromIterator(page.getElements().iterator().asScala))
-        .map(jacksonToCirce(_))
-        .evalMap(_.as[A].liftTo[F])
+        .flatMap(page => Stream.iterable(page.getElements().asScala))
+        .evalMapChunk(jacksonToCirce(_).as[A].liftTo[F])
   }
 
   private class MapKRawCosmosContainer[F[_], G[_], V](


### PR DESCRIPTION
At the moment we have singleton chunks in the `Stream` returned by the query methods.

- We use `fromIterator` and don't specify a chunk size.
- We use `evalMap` to decode the JSON.

In this PR I change it to have one chunk per page. 