### PR TITLE
Minor improvements in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,12 @@
 name: CI
-on: [push, pull_request]
+
+on: pull_request
+
 env:
   CI: true
   CI_SNAPSHOT_RELEASE: +publishSigned
   SCALA_VERSION: 2.13.5
+
 jobs:
   validate:
     name: Scala ${{ matrix.scala }}, Java ${{ matrix.java }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check formatting
         if: startsWith(matrix.scala, '2.13.') && (matrix.java == 'adopt@1.11')
-        run: sbt ++$SCALA_VERSION scalafmtCheckAll
+        run: sbt ++$SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck
 
       - name: Check copyright headers
         if: matrix.java == 'adopt@1.11'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,56 +22,70 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.java }}
-      - name: Cache Coursier
+
+      - name: Cache sbt
         uses: actions/cache@v2
         with:
-          path: ~/.cache/coursier
-          key: sbt-coursier-cache
-      - name: Cache SBT
-        uses: actions/cache@v2
-        with:
-          path: ~/.sbt
-          key: sbt-${{ hashFiles('**/build.sbt') }}
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
       - name: Check formatting
-        if: startsWith(matrix.scala, '2.13.') && (matrix.java == 'adopt@1.8')
+        if: startsWith(matrix.scala, '2.13.') && (matrix.java == 'adopt@1.11')
         run: sbt ++$SCALA_VERSION scalafmtCheckAll
+
       - name: Check copyright headers
-        if: matrix.java == 'adopt@1.8'
+        if: matrix.java == 'adopt@1.11'
         run: sbt ++$SCALA_VERSION headerCheck
+
       - name: Compile
         run: sbt ++$SCALA_VERSION test:compile
+
       - name: Check compatibility
         run: sbt ++$SCALA_VERSION mimaReportBinaryIssues
+
       - name: Test
         run: sbt ++$SCALA_VERSION test
+
       - name: Scaladoc
         run: sbt ++$SCALA_VERSION doc
+
   docs:
     name: Doc Site
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: olafurpg/setup-scala@v10
-      - name: Cache Coursier
-        uses: actions/cache@v1
         with:
-          path: ~/.cache/coursier
-          key: sbt-coursier-cache
-      - name: Cache SBT
+          java-version: adopt@1.11
+
+      - name: Cache sbt
         uses: actions/cache@v2
         with:
-          path: ~/.sbt
-          key: sbt-${{ hashFiles('**/build.sbt') }}
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.6
+
       - name: Install Jekyll
         run: |
           gem install bundler
           bundle install --gemfile=site/Gemfile
+
       - name: Build project site
         run: sbt ++$SCALA_VERSION site/makeMicrosite

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,8 @@ on:
 
 env:
   CI: true
-  SCALA_VERSION: 2.12.13
+  SCALA_VERSION: 2.13.5
+
 jobs:
   release:
     name: Release
@@ -20,18 +21,23 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 0
+
       - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+
       - uses: olafurpg/setup-gpg@v3
-      - name: Cache Coursier
+
+      - name: Cache sbt
         uses: actions/cache@v2
         with:
-          path: ~/.cache/coursier
-          key: sbt-coursier-cache
-      - name: Cache SBT
-        uses: actions/cache@v2
-        with:
-          path: ~/.sbt
-          key: sbt-${{ hashFiles('**/build.sbt') }}
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
       - name: Publish
         run: sbt ci-release
         env:
@@ -39,14 +45,17 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.6
+
       - name: Install Jekyll
         run: |
           gem install bundler
           bundle install --gemfile=site/Gemfile
+
       - name: Publish microsite
         run: |
           sbt ++$SCALA_VERSION site/publishMicrosite

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
@@ -37,6 +37,24 @@ jobs:
             ~/.coursier/cache/v1
             ~/.cache/coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Check formatting
+        run: sbt scalafmtCheckAll scalafmtSbtCheck
+
+      - name: Check copyright headers
+        run: sbt headerCheck
+
+      - name: Compile
+        run: sbt test:compile
+
+      - name: Check compatibility
+        run: sbt mimaReportBinaryIssues
+
+      - name: Test
+        run: sbt test
+
+      - name: Scaladoc
+        run: sbt doc
 
       - name: Publish
         run: sbt ci-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,14 @@
 name: Release
+
 on:
   push:
     branches:
       - master
       - main
+      - series/*
     tags:
-      - '*'
+      - v*
+
 env:
   CI: true
   SCALA_VERSION: 2.12.13

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,11 +1,13 @@
-version = "2.5.3"
+version = "2.7.4"
 
 maxColumn = 100
 
 continuationIndent.callSite = 2
 
 newlines {
+  afterCurlyLambdaParams = "preserve"
   sometimesBeforeColonInMethodReturnType = false
+  beforeCurlyLambdaParams = "multilineWithCaseOnly"
 }
 
 align {
@@ -19,17 +21,12 @@ align {
   tokens = ["%", "%%"]
 }
 
-danglingParentheses.preset = false
-
 docstrings = JavaDoc
 
 rewrite {
-  rules = [
-    AvoidInfix
-    RedundantBraces
-    RedundantParens
-    AsciiSortImports
-    PreferCurlyFors
-  ]
-  redundantBraces.maxLines = 1
+  rules = [SortImports, RedundantBraces]
+  redundantBraces {
+    maxLines = 1
+    generalExpressions = true
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -65,11 +65,13 @@ lazy val site = project
         file("CODE_OF_CONDUCT.md") -> ExtraMdFileConfig(
           "code-of-conduct.md",
           "page",
-          Map("title" -> "code of conduct", "section" -> "code of conduct", "position" -> "100")),
+          Map("title" -> "code of conduct", "section" -> "code of conduct", "position" -> "100")
+        ),
         file("LICENSE") -> ExtraMdFileConfig(
           "license.md",
           "page",
-          Map("title" -> "license", "section" -> "license", "position" -> "101"))
+          Map("title" -> "license", "section" -> "license", "position" -> "101")
+        )
       )
     )
   }
@@ -77,8 +79,8 @@ lazy val site = project
 // General Settings
 lazy val commonSettings = Seq(
   crossScalaVersions := Seq(scalaVersion.value, "2.12.13"),
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorV cross CrossVersion.full),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % betterMonadicForV),
+  addCompilerPlugin("org.typelevel" %% "kind-projector"     % kindProjectorV cross CrossVersion.full),
+  addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
   libraryDependencies ++= Seq(
     "com.azure"           % "azure-cosmos"            % "4.14.0",
     "com.microsoft.azure" % "azure-documentdb"        % "2.6.1",
@@ -137,4 +139,5 @@ inThisBuild(
     organizationName := "Jack Henry & Associates, Inc.®",
     startYear := Some(2020),
     licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
-  ))
+  )
+)

--- a/core/src/main/scala/com/banno/cosmos4s/CosmosBulkClient.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/CosmosBulkClient.scala
@@ -68,8 +68,10 @@ object CosmosBulkClient {
 
     def insert(value: List[Json]): F[Unit] =
       Sync[F]
-        .delay(executor
-          .importAll(value.map(_.noSpaces).asJava, false, true, maxConcurrencyPerPartitionRange))
+        .delay(
+          executor
+            .importAll(value.map(_.noSpaces).asJava, false, true, maxConcurrencyPerPartitionRange)
+        )
         .map(Option(_)) >>= {
         _.fold(NoneResponseCosmosBulkInsertFailure.raiseError[F, Unit]) { r =>
           if (r.getNumberOfDocumentsImported() == value.size)
@@ -81,8 +83,10 @@ object CosmosBulkClient {
 
     def upsert(value: List[Json]): F[Unit] =
       Sync[F]
-        .delay(executor
-          .importAll(value.map(_.noSpaces).asJava, true, true, maxConcurrencyPerPartitionRange))
+        .delay(
+          executor
+            .importAll(value.map(_.noSpaces).asJava, true, true, maxConcurrencyPerPartitionRange)
+        )
         .map(Option(_)) >>= {
         _.fold(
           NoneResponseCosmosBulkUpsertFailure.raiseError[F, Unit]

--- a/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/IndexedCosmosContainer.scala
@@ -32,11 +32,13 @@ trait IndexedCosmosContainer[F[_], K, I, V] {
   def query(
       partitionKey: K,
       query: String,
-      overrides: QueryOptions => QueryOptions = identity): Stream[F, V]
+      overrides: QueryOptions => QueryOptions = identity
+  ): Stream[F, V]
   def queryCustom[A: Decoder](
       partitionKey: K,
       query: String,
-      overrides: QueryOptions => QueryOptions = identity): Stream[F, A]
+      overrides: QueryOptions => QueryOptions = identity
+  ): Stream[F, A]
   def lookup(partitionKey: K, id: I): F[Option[V]]
   def insert(partitionKey: K, value: V): F[Option[V]]
   def replace(partitionKey: K, id: I, value: V): F[Option[V]]
@@ -50,10 +52,12 @@ trait IndexedCosmosContainer[F[_], K, I, V] {
   def contramapId[A](f: A => I): IndexedCosmosContainer[F, K, A, V] =
     new IndexedCosmosContainer.ContramapId(this, f)
   def semiInvariantFlatMap[A](f: V => F[A])(g: A => V)(implicit
-      F: Monad[F]): IndexedCosmosContainer[F, K, I, A] =
+      F: Monad[F]
+  ): IndexedCosmosContainer[F, K, I, A] =
     new IndexedCosmosContainer.SemiInvariantFlatMap(this, f, g)
   def imapValue[A](f: V => A)(g: A => V)(implicit
-      F: Functor[F]): IndexedCosmosContainer[F, K, I, A] =
+      F: Functor[F]
+  ): IndexedCosmosContainer[F, K, I, A] =
     new IndexedCosmosContainer.ImapValue(this, f, g)
 }
 
@@ -61,17 +65,14 @@ object IndexedCosmosContainer {
 
   def impl[F[_]: ConcurrentEffect: ContextShift](
       container: CosmosAsyncContainer,
-      createFeedOptions: Option[F[QueryOptions]] = None): IndexedCosmosContainer[
-    F,
-    String,
-    String,
-    Json] =
+      createFeedOptions: Option[F[QueryOptions]] = None
+  ): IndexedCosmosContainer[F, String, String, Json] =
     new BaseImpl[F](container, createFeedOptions)
 
   private class BaseImpl[F[_]: ConcurrentEffect: ContextShift](
       container: CosmosAsyncContainer,
-      createFeedOptions: Option[F[QueryOptions]] = None)
-      extends IndexedCosmosContainer[F, String, String, Json] {
+      createFeedOptions: Option[F[QueryOptions]] = None
+  ) extends IndexedCosmosContainer[F, String, String, Json] {
 
     private def createFeedOptionsAlways: F[QueryOptions] =
       createFeedOptions.getOrElse(Sync[F].delay(QueryOptions.default))
@@ -81,13 +82,15 @@ object IndexedCosmosContainer {
     def query(
         partitionKey: String,
         query: String,
-        overrides: QueryOptions => QueryOptions = identity): Stream[F, Json] =
+        overrides: QueryOptions => QueryOptions = identity
+    ): Stream[F, Json] =
       queryCustom[Json](partitionKey, query, overrides)
 
     def queryCustom[A: Decoder](
         partitionKey: String,
         query: String,
-        overrides: QueryOptions => QueryOptions = identity): Stream[F, A] =
+        overrides: QueryOptions => QueryOptions = identity
+    ): Stream[F, A] =
       Stream
         .eval(createFeedOptionsAlways)
         .map(overrides)
@@ -98,7 +101,8 @@ object IndexedCosmosContainer {
                 .queryItems(
                   query,
                   options.build().setPartitionKey(new PartitionKey(partitionKey)),
-                  classOf[JsonNode])
+                  classOf[JsonNode]
+                )
                 .byPage()
             )
           )
@@ -123,8 +127,10 @@ object IndexedCosmosContainer {
                   id,
                   new PartitionKey(partitionKey),
                   new CosmosItemRequestOptions(),
-                  classOf[JsonNode])
-              ))
+                  classOf[JsonNode]
+                )
+              )
+            )
             .recoverWith { case _: NotFoundException => Sync[F].pure(None) }
         )
         .subflatMap(response => Option(response.getItem()))
@@ -135,8 +141,14 @@ object IndexedCosmosContainer {
       cats.data.OptionT
         .liftF(Sync[F].delay(new CosmosItemRequestOptions()))
         .flatMap(options =>
-          cats.data.OptionT(ReactorCore.monoToEffectOpt(Sync[F].delay(
-            container.createItem(circeToJackson(value), new PartitionKey(partitionKey), options)))))
+          cats.data.OptionT(
+            ReactorCore.monoToEffectOpt(
+              Sync[F].delay(
+                container.createItem(circeToJackson(value), new PartitionKey(partitionKey), options)
+              )
+            )
+          )
+        )
         .subflatMap(response => Option(response.getItem()))
         .map(jacksonToCirce)
         .value
@@ -147,7 +159,8 @@ object IndexedCosmosContainer {
           ReactorCore.monoToEffectOpt(
             Sync[F].delay(
               container.replaceItem(circeToJackson(value), id, new PartitionKey(partitionKey))
-            ))
+            )
+          )
         )
         .subflatMap(response => Option(response.getItem()))
         .map(jacksonToCirce)
@@ -159,7 +172,8 @@ object IndexedCosmosContainer {
           ReactorCore.monoToEffectOpt(
             Sync[F].delay(
               container.upsertItem(circeToJackson(value))
-            ))
+            )
+          )
         )
         .subflatMap(response => Option(response.getItem()))
         .map(jacksonToCirce)
@@ -170,7 +184,8 @@ object IndexedCosmosContainer {
         .monoToEffect(
           Sync[F].delay(
             container.deleteItem(id, new PartitionKey(partitionKey))
-          ))
+          )
+        )
         .void
   }
 
@@ -181,12 +196,14 @@ object IndexedCosmosContainer {
     def query(
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions = identity): Stream[G, V] =
+        overrides: QueryOptions => QueryOptions = identity
+    ): Stream[G, V] =
       base.query(partitionKey, query, overrides).translate(fk)
     def queryCustom[A: Decoder](
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions = identity): Stream[G, A] =
+        overrides: QueryOptions => QueryOptions = identity
+    ): Stream[G, A] =
       base.queryCustom[A](partitionKey, query, overrides).translate(fk)
     def lookup(partitionKey: K, id: I): G[Option[V]] =
       fk(base.lookup(partitionKey, id))
@@ -207,12 +224,14 @@ object IndexedCosmosContainer {
     def query(
         partitionKey: K2,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, V] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, V] =
       base.query(contra(partitionKey), query, overrides)
     def queryCustom[A: Decoder](
         partitionKey: K2,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, A] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, A] =
       base.queryCustom(contra(partitionKey), query, overrides)
     def lookup(partitionKey: K2, id: I): F[Option[V]] =
       base.lookup(contra(partitionKey), id)
@@ -233,12 +252,14 @@ object IndexedCosmosContainer {
     def query(
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, V] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, V] =
       base.query(partitionKey, query, overrides)
     def queryCustom[A: Decoder](
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, A] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, A] =
       base.queryCustom(partitionKey, query, overrides)
     def lookup(partitionKey: K, id: I2): F[Option[V]] =
       base.lookup(partitionKey, contra(id))
@@ -260,14 +281,16 @@ object IndexedCosmosContainer {
     def query(
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, V2] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, V2] =
       base
         .query(partitionKey, query, overrides)
         .evalMap(f)
     def queryCustom[A: Decoder](
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, A] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, A] =
       base.queryCustom(partitionKey, query, overrides)
     def lookup(partitionKey: K, id: I): F[Option[V2]] =
       base.lookup(partitionKey, id).flatMap(_.traverse(f))
@@ -289,14 +312,16 @@ object IndexedCosmosContainer {
     def query(
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, V2] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, V2] =
       base
         .query(partitionKey, query, overrides)
         .map(f)
     def queryCustom[A: Decoder](
         partitionKey: K,
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, A] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, A] =
       base.queryCustom(partitionKey, query, overrides)
     def lookup(partitionKey: K, id: I): F[Option[V2]] =
       base.lookup(partitionKey, id).map(_.map(f))
@@ -313,14 +338,16 @@ object IndexedCosmosContainer {
   implicit def partitionKey[F[_], I, V] =
     new Contravariant[IndexedCosmosContainer[F, *, I, V]] {
       def contramap[A, B](fa: IndexedCosmosContainer[F, A, I, V])(
-          f: B => A): IndexedCosmosContainer[F, B, I, V] =
+          f: B => A
+      ): IndexedCosmosContainer[F, B, I, V] =
         fa.contramapPartitionKey(f)
     }
 
   implicit def id[F[_], K, V] =
     new Contravariant[IndexedCosmosContainer[F, K, *, V]] {
       def contramap[A, B](fa: IndexedCosmosContainer[F, K, A, V])(
-          f: B => A): IndexedCosmosContainer[F, K, B, V] =
+          f: B => A
+      ): IndexedCosmosContainer[F, K, B, V] =
         fa.contramapId(f)
     }
 }

--- a/core/src/main/scala/com/banno/cosmos4s/RawCosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/RawCosmosContainer.scala
@@ -30,7 +30,8 @@ trait RawCosmosContainer[F[_], V] {
   def queryRaw(query: String, overrides: QueryOptions => QueryOptions = identity): Stream[F, V]
   def queryCustomRaw[A: Decoder](
       query: String,
-      overrides: QueryOptions => QueryOptions = identity): Stream[F, A]
+      overrides: QueryOptions => QueryOptions = identity
+  ): Stream[F, A]
 
   def map[A](f: V => A): RawCosmosContainer[F, A] =
     new RawCosmosContainer.MapValueRawCosmosContainter(this, f)
@@ -43,13 +44,14 @@ trait RawCosmosContainer[F[_], V] {
 object RawCosmosContainer {
   def impl[F[_]: ConcurrentEffect: ContextShift](
       container: CosmosAsyncContainer,
-      createQueryOptions: Option[F[QueryOptions]] = None): RawCosmosContainer[F, Json] =
+      createQueryOptions: Option[F[QueryOptions]] = None
+  ): RawCosmosContainer[F, Json] =
     new BaseImpl[F](container, createQueryOptions)
 
   private class BaseImpl[F[_]: ConcurrentEffect: ContextShift](
       container: CosmosAsyncContainer,
-      createQueryOptions: Option[F[QueryOptions]] = None)
-      extends RawCosmosContainer[F, Json] {
+      createQueryOptions: Option[F[QueryOptions]] = None
+  ) extends RawCosmosContainer[F, Json] {
 
     def createQueryOptionsAlways: F[QueryOptions] =
       createQueryOptions.getOrElse(Sync[F].delay(QueryOptions.default))
@@ -58,12 +60,14 @@ object RawCosmosContainer {
 
     def queryRaw(
         query: String,
-        overrides: QueryOptions => QueryOptions = identity): Stream[F, Json] =
+        overrides: QueryOptions => QueryOptions = identity
+    ): Stream[F, Json] =
       queryCustomRaw[Json](query, overrides)
 
     def queryCustomRaw[A: Decoder](
         query: String,
-        overrides: QueryOptions => QueryOptions = identity): Stream[F, A] =
+        overrides: QueryOptions => QueryOptions = identity
+    ): Stream[F, A] =
       Stream
         .eval(createQueryOptionsAlways)
         .map(overrides)
@@ -95,7 +99,8 @@ object RawCosmosContainer {
       base.queryRaw(query, overrides).translate(fk)
     def queryCustomRaw[A: Decoder](
         query: String,
-        overrides: QueryOptions => QueryOptions = identity): Stream[G, A] =
+        overrides: QueryOptions => QueryOptions = identity
+    ): Stream[G, A] =
       base.queryCustomRaw(query, overrides).translate(fk)
   }
 
@@ -108,7 +113,8 @@ object RawCosmosContainer {
 
     def queryCustomRaw[B: Decoder](
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, B] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, B] =
       base.queryCustomRaw(query, overrides)
   }
 
@@ -121,7 +127,8 @@ object RawCosmosContainer {
 
     def queryCustomRaw[B: Decoder](
         query: String,
-        overrides: QueryOptions => QueryOptions): Stream[F, B] =
+        overrides: QueryOptions => QueryOptions
+    ): Stream[F, B] =
       base.queryCustomRaw(query, overrides)
   }
 

--- a/core/src/main/scala/com/banno/cosmos4s/ReactorCore.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/ReactorCore.scala
@@ -36,9 +36,11 @@ object ReactorCore {
   def monoToEffect[F[_]: ConcurrentEffect: ContextShift, A](m: F[Mono[A]]): F[A] =
     monoToEffectOpt(m).flatMap(opt =>
       opt.fold(
-        Sync[F].raiseError[A](new Throwable("Mono to Effect Conversion failed to produce value"))) {
+        Sync[F].raiseError[A](new Throwable("Mono to Effect Conversion failed to produce value"))
+      ) {
         Sync[F].pure
-      })
+      }
+    )
 
   def fluxToStream[F[_]: ConcurrentEffect: ContextShift, A](m: F[Flux[A]]): fs2.Stream[F, A] =
     Stream
@@ -46,5 +48,6 @@ object ReactorCore {
       .flatMap(fromPublisher[F, A])
       .chunks
       .flatMap(chunk =>
-        Stream.eval(ContextShift[F].shift).flatMap(_ => Stream.chunk(chunk).covary[F]))
+        Stream.eval(ContextShift[F].shift).flatMap(_ => Stream.chunk(chunk).covary[F])
+      )
 }

--- a/core/src/main/scala/com/banno/cosmos4s/types/QueryOptions.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/types/QueryOptions.scala
@@ -20,12 +20,13 @@ import com.azure.cosmos.models.CosmosQueryRequestOptions
 
 final class QueryOptions private (
     maxDegreeOfParallelism: Option[Int],
-    maxBufferedItemCount: Option[Int])
-    extends Serializable {
+    maxBufferedItemCount: Option[Int]
+) extends Serializable {
 
   private[this] def copy(
       maxDegreeOfParallelism: Option[Int] = maxDegreeOfParallelism,
-      maxBufferedItemCount: Option[Int] = maxBufferedItemCount): QueryOptions =
+      maxBufferedItemCount: Option[Int] = maxBufferedItemCount
+  ): QueryOptions =
     new QueryOptions(maxDegreeOfParallelism, maxBufferedItemCount)
 
   def withMaxDegreeOfParallelism(value: Option[Int]): QueryOptions =


### PR DESCRIPTION
- Run `CI` only for pull request events
- Improve `sbt` and `coursier` cache
- Use `adopt@1.11` as the default java version
- Enable `Release` workflow in branches `series/*`
- Check sbt format with scalafmt
- Add steps in `Release` workflow
	- Check formating
	- Check headers
	- Compile
	- Test
	- scaladoc