### PR TITLE
Preserve chunks in semiInvariantFlatMapStreamResult

### DIFF
--- a/core/src/main/scala/com/banno/cosmos4s/CosmosContainer.scala
+++ b/core/src/main/scala/com/banno/cosmos4s/CosmosContainer.scala
@@ -305,7 +305,7 @@ object CosmosContainer {
         parameters: Map[String, Any],
         options: QueryOptions
     ): Stream[F, StreamResult[A]] =
-      base.query(query, parameters, options).evalMap(_.traverse(f))
+      base.query(query, parameters, options).evalMapChunk(_.traverse(f))
     def lookup(
         partitionKey: Key,
         id: Id,


### PR DESCRIPTION
We use `semiInvariantFlatMapStreamResult` to decode the response json, but the `evalMap` in the implementation means that we lose the `Chunk`s per page returned in `BaseCosmosContainer`s `query`.

Similar is what I did for `IndexedCosmosContainer.SemiInvariantFlatMap` in https://github.com/Banno/cosmos4s/pull/75.